### PR TITLE
fix change to typeName

### DIFF
--- a/numpy/__init__.js
+++ b/numpy/__init__.js
@@ -946,7 +946,7 @@ var $builtinmodule = function (name) {
     };
 
     function Internal_DType_To_Num(dtype) {
-        var name = Sk.abstr.typeName(dtype);
+        var name = dtype.prototype && dtype.prototype.tp$name;
         var num = Internal_TypeTable[name];
 
         if (num == null) {


### PR DESCRIPTION
on skulpt master `Sk.abstr.typeName` was updated so that it returns `"type"` for type objects. 
the change in this pr addresses the issue: https://github.com/skulpt/skulpt/issues/1179

the change in this pr is compatible with current and past versions of skulpt. 